### PR TITLE
Support $set field update operator - field order test case 

### DIFF
--- a/integration/query_set_test.go
+++ b/integration/query_set_test.go
@@ -106,8 +106,10 @@ func TestSetOperatorOnString(t *testing.T) {
 			err: &mongo.WriteError{
 				Code: 9,
 				Message: "Modifiers operate on fields but we found type array instead. " +
-					"For example: {$mod: {<field>: ...}} not {$set: array}",
+					"For example: {$mod: {<field>: ...}} not {$set: []}",
 			},
+			alt: "Modifiers operate on fields but we found type array instead. " +
+				"For example: {$mod: {<field>: ...}} not {$set: array}",
 		},
 		"SetEmptyDoc": {
 			id:     "string",

--- a/internal/handlers/common/update.go
+++ b/internal/handlers/common/update.go
@@ -45,7 +45,9 @@ func UpdateDocument(doc, update *types.Document) (bool, error) {
 				return true, nil
 			default:
 				msgFmt := fmt.Sprintf(`Modifiers operate on fields but we found type %[1]s instead. `+
-					`For example: {$mod: {<field>: ...}} not {$set: %[1]s}`, AliasFromType(updateV))
+					`For example: {$mod: {<field>: ...}} not {$set: %[1]s}`,
+					AliasFromType(updateV),
+				)
 				return false, NewWriteErrorMsg(ErrFailedToParse, msgFmt)
 			}
 


### PR DESCRIPTION
Refs https://github.com/FerretDB/FerretDB/issues/627.

```go
"SetMany": {
	id:     "string",
	update: bson.D{{"$set", bson.D{{"foo", int32(1)}, {"bar", bson.A{}}}}},
	stat: &mongo.UpdateResult{
		MatchedCount:  1,
		ModifiedCount: 1,
		UpsertedCount: 0,
	},
	result: bson.D{{"_id", "string"}, {"value", "foo"}, {"bar", bson.A{}}, {"foo", int32(1)}},
}
```
.